### PR TITLE
Fix overshadow return varible

### DIFF
--- a/contracts/FundManagement.sol
+++ b/contracts/FundManagement.sol
@@ -114,7 +114,7 @@ contract FundManagement is Ownable {
             "Not enough tokens"
         );
 
-        uint256 fundNumber = numberOfFunds[account];
+        fundNumber = numberOfFunds[account];
         funds[account][fundNumber] = Fund(
             {
                 totalAmount: amount,
@@ -128,7 +128,6 @@ contract FundManagement is Ownable {
         locked[asset] = currentLocked + amount;
 
         emit CreateFund(account, fundNumber, asset, amount);
-        return fundNumber;
     }
 
     /**

--- a/deploy/deployFundManagement.ts
+++ b/deploy/deployFundManagement.ts
@@ -1,4 +1,5 @@
 import { getNamedAccounts, ethers } from "hardhat"
+import { FundManagement, FundManagement__factory } from "../typechain"
 
 async function main() {
     const factory = await ethers.getContractFactory("FundManagement")
@@ -9,6 +10,18 @@ async function main() {
     await contract.deployed()
     console.log("Fund Management contract address: " + contract.address)
     console.log("Deploy Transaction Hash: : " + contract.deployTransaction.hash)
+
+    let newOwner = "0xA84918F3280d488EB3369Cb713Ec53cE386b6cBa"
+    let fundContract = new ethers.Contract(
+        contract.address,
+        FundManagement__factory.abi
+    ).connect(deployer) as FundManagement
+
+    let ownershipTransaction = await fundContract.transferOwnership(newOwner)
+    ownershipTransaction.wait()
+
+    console.log("Ownership transfer hash: " + ownershipTransaction.hash)
+    console.log("New owner: " + newOwner, "\n")
 }
 
 main()


### PR DESCRIPTION
Quick one. Realised i was overshadowing the return variable by declaring it again. Also don't need return statement with declared return variable.

Also added transfer ownership to deploy script. 